### PR TITLE
Add examples directive

### DIFF
--- a/lib/rspec/openapi/record.rb
+++ b/lib/rspec/openapi/record.rb
@@ -1,17 +1,18 @@
 RSpec::OpenAPI::Record = Struct.new(
-  :method,                # @param [String]  - "GET"
-  :path,                  # @param [String]  - "/v1/status/:id"
-  :path_params,           # @param [Hash]    - {:controller=>"v1/statuses", :action=>"create", :id=>"1"}
-  :query_params,          # @param [Hash]    - {:query=>"string"}
-  :request_params,        # @param [Hash]    - {:request=>"body"}
-  :request_content_type,  # @param [String]  - "application/json"
-  :request_headers,       # @param [Array]  - [["header_key1", "header_value1"], ["header_key2", "header_value2"]]
-  :summary,               # @param [String]  - "v1/statuses #show"
-  :tags,                  # @param [Array]   - ["Status"]
-  :description,           # @param [String]  - "returns a status"
-  :status,                # @param [Integer] - 200
-  :response_body,         # @param [Object]  - {"status" => "ok"}
-  :response_content_type, # @param [String]  - "application/json"
+  :method,                       # @param [String]  - "GET"
+  :path,                         # @param [String]  - "/v1/status/:id"
+  :path_params,                  # @param [Hash]    - {:controller=>"v1/statuses", :action=>"create", :id=>"1"}
+  :query_params,                 # @param [Hash]    - {:query=>"string"}
+  :request_params,               # @param [Hash]    - {:request=>"body"}
+  :request_content_type,         # @param [String]  - "application/json"
+  :request_headers,              # @param [Array]   - [["header_key1", "header_value1"], ["header_key2", "header_value2"]]
+  :summary,                      # @param [String]  - "v1/statuses #show"
+  :tags,                         # @param [Array]   - ["Status"]
+  :description,                  # @param [String]  - "returns a status"
+  :status,                       # @param [Integer] - 200
+  :response_body,                # @param [Object]  - {"status" => "ok"}
+  :response_content_type,        # @param [String]  - "application/json"
   :response_content_disposition, # @param [String]  - "inline"
+  :examples,                     # @param [Boolean] - true
   keyword_init: true,
 )

--- a/lib/rspec/openapi/record_builder.rb
+++ b/lib/rspec/openapi/record_builder.rb
@@ -57,6 +57,7 @@ class << RSpec::OpenAPI::RecordBuilder = Object.new
       response_body: response_body,
       response_content_type: response.media_type,
       response_content_disposition: response.header["Content-Disposition"],
+      examples: metadata_options[:examples].nil? ? RSpec::OpenAPI.enable_example : metadata_options[:examples],
     ).freeze
   end
 

--- a/lib/rspec/openapi/schema_builder.rb
+++ b/lib/rspec/openapi/schema_builder.rb
@@ -36,13 +36,9 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
   private
 
   def response_example(record, disposition:)
-    return nil if !example_enabled? || disposition
+    return nil if !record.examples || disposition
 
     record.response_body
-  end
-
-  def example_enabled?
-    RSpec::OpenAPI.enable_example
   end
 
   def build_parameters(record)
@@ -54,7 +50,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
         in: 'path',
         required: true,
         schema: build_property(try_cast(value)),
-        example: (try_cast(value) if example_enabled?),
+        example: (try_cast(value) if record.examples),
       }.compact
     end
 
@@ -63,7 +59,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
         name: build_parameter_name(key, value),
         in: 'query',
         schema: build_property(try_cast(value)),
-        example: (try_cast(value) if example_enabled?),
+        example: (try_cast(value) if record.examples),
       }.compact
     end
 
@@ -73,7 +69,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
         in: 'header',
         required: true,
         schema: build_property(try_cast(value)),
-        example: (try_cast(value) if example_enabled?),
+        example: (try_cast(value) if record.examples),
       }.compact
     end
 
@@ -99,7 +95,7 @@ class << RSpec::OpenAPI::SchemaBuilder = Object.new
       content: {
         normalize_content_type(record.request_content_type) => {
           schema: build_property(record.request_params),
-          example: (build_example(record.request_params) if example_enabled?),
+          example: (build_example(record.request_params) if record.examples),
         }.compact
       }
     }


### PR DESCRIPTION
Allow to pass examples generation directive to a single spec. It will override global rule to examples generation.